### PR TITLE
[Feat] Added AdminController with authentication and customized routes…

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,5 @@
+class AdminController < ApplicationController
+  before_action :authenticate_admin!
+  def index
+  end
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,6 +1,3 @@
 class Admin < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  devise :database_authenticatable, :recoverable, :rememberable, :validatable
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Admin Index</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,16 @@
 Rails.application.routes.draw do
-  devise_for :admins
+  devise_for :admins, skip: [ :registrations ]
   devise_for :users
   resources :movies
   # Render dynamic PWA files from app/views/pwa/*
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+
+  authenticated :admin_user do
+    root to: "admin#index", as: :admin_root
+  end
+
+  get "admin" => "admin#index"
 
   # Defines the root path route ("/")
   root "movies#index"


### PR DESCRIPTION
## Summary of Changes
- Created `AdminController` with an `index` action and `before_action` to authenticate admins.
- Modified the Admin Devise model to remove the `registrable` module and only include `database_authenticatable`, `recoverable`, `rememberable`, and `validatable`.
- Updated routes to skip `registrations` for admins and set up a custom root path for authenticated admin users.
- Added a simple "Admin Index" page to verify that the Admin controller is working.

## Checklist
- [X] The code works as expected.
- [X] The code follows the project's style guidelines.
