### PR TITLE
feat: Add paid content functionality and enhance movie details

### DIFF
--- a/app/views/movies/_sidebar.html.erb
+++ b/app/views/movies/_sidebar.html.erb
@@ -1,0 +1,44 @@
+<div class="flex flex-col lg:pl-6">
+    <div class="mt-6 lg:mt-0 flex justify-center items-center w-full">
+        <div class="bg-white rounded-lg shadow-lg overflow-hidden w-full">
+            <div class="bg-amaranth-500 p-4">
+                <h2 class="text-white-50 text-2xl font-bold">Start watching</h2>
+            </div>
+            <div class="p-4">
+                <% if user_signed_in? %>
+                    <p class="text-gray-700 text-base mb-4">
+                        Start the movie and begin watching the episodes to learn more about the topic.
+                    </p>
+                    <%= link_to "Start Movie", movie_episode_path(@movie, @movie.first_episode), class: "bg-revolver-600 hover:bg-revolver-700 text-white-50 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline w-full transition ease-in-out duration-150 " %> %>
+                <% else %>
+                    <p class="text-gray-700 text-base mb-4">
+                        Sign up for free today and start exploring the new addventure
+                    </p>
+                    <%= link_to "Sign Up", new_user_registration_path, class: "bg-revolver-600 hover:bg-revolver-700 text-white-50 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline w-full transition ease-in-out duration-150 " %>
+                <% end %>
+            </div>
+            <% if @movie.paid %>
+                <div class="mt-6 flex justify-center items-center w-full">
+                    <div class="bg-white rounded-lg shadow-lg overflow-hidden w-full">
+                        <div class="bg-amaranth-500 p-4">
+                            <h2 class="text-white-50 text-2xl font-bold">Get more content</h2>
+                        </div>
+                        <div class="p-4">
+                            <% if user_signed_in? %>
+                                <p class="text-gray-700 text-base mb-4">
+                                    Unlock the full movie and start watching all the episodes.
+                                </p> 
+                                <button class="bg-revolver-600 hover:bg-revolver700 text-white-50 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline w-full transition ease-in-out duration-150">Unlock Full Movie</button>
+                            <% else %>
+                                <p class="text-gray-700 text-base mb-4">
+                                    Sign up for free and start exploring the endless possibilities.
+                                </p> 
+                                <%= link_to "Sign Up", new_user_registration_path, class: "bg-revolver-600 hover:bg-revolver-700 text-white-50 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline w-full transition ease-in-out duration-150 " %>
+                            <% end %>
+                        </div>
+                    </div> 
+                </div>
+            <% end %>
+        </div>
+    </div>
+</div>

--- a/app/views/movies/show.html.erb
+++ b/app/views/movies/show.html.erb
@@ -11,10 +11,16 @@
     <div class="border p-6 rounded">
       <div class="flex justify-start items-center flex-wrap w-full mb-5">
         <% @movie.genres.each do |genre| %>
-          <div class="bg-amaranth-100 text-amaranth-800 text-sm font-bold mt-2 mr-2 px-2.5 py-0.5 rounded"><%= genre.name %></div>
+          <div class="bg-amaranth-100 text-amaranth-800 text-sm font-semibold mt-2 mr-2 px-2.5 py-0.5 rounded"><%= genre.name %></div>
         <% end %>
       </div>
+      <span><%= @movie.episodes.count %> <%= "episode".pluralize(@movie.episodes.count) %></span>
+      <h1 class="text-2xl font-bold"><%= @movie.title %></h1>
+      <p class="text-gray-500 mt-2"><%= @movie.description %></p>
+    </div>
+
+    <div>
+      <%= render "sidebar" %>
     </div>
   </div>
-
 </div>

--- a/db/migrate/20250116020300_add_more_cols_to_movie.rb
+++ b/db/migrate/20250116020300_add_more_cols_to_movie.rb
@@ -1,0 +1,7 @@
+class AddMoreColsToMovie < ActiveRecord::Migration[7.2]
+  def change
+    add_column :movies, :paid, :boolean
+    add_column :movies, :stripe_price_id, :string
+    add_column :movies, :premium_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_15_002856) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_16_020300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,6 +84,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_15_002856) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "paid"
+    t.string "stripe_price_id"
+    t.text "premium_description"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## Description
This MR introduces the ability to mark movies as paid content and enhances the movie details view to conditionally display options for unlocking paid content. It also includes the necessary database migrations and updates to the movie view template.

## Changes
- Added `paid`, `stripe_price_id`, and `premium_description` columns to the `movies` table
- Updated the movie view to conditionally display paid content options based on user authentication and movie payment status
- Enhanced the sidebar rendering and movie details display

## Checklist
- [X] Database migrations have been tested and applied
- [X] New functionality has been tested and works as expected
- [X] Code has been reviewed and meets coding standards