### PR TITLE
[Feat] Implement episode access restriction for paid content

### DIFF
--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -1,6 +1,8 @@
 class EpisodesController < ApplicationController
   before_action :set_episode, only: %i[ show update ]
   before_action :set_movie
+  before_action :check_paid
+
   def show
     @completed_episodes = current_user.episode_users.where(completed: true).pluck(:episode_id)
     @movie = @episode.movie
@@ -27,5 +29,15 @@ class EpisodesController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_episode
       @episode = Episode.find(params[:id])
+    end
+
+    def check_paid
+      if @episode.paid && !current_user.movie_users.where(movie_id: params[:movie_id]).exists?
+        if @episode.previous_episode
+          redirect_to movie_episode_path(@movie, @episode.previous_episode), notice: "You must purchase the full movie to access the next episode"
+        else
+          redirect_to movie_path(@movie), notice: "You must purchase the full movie to access the next episode"
+        end
+      end
     end
 end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -2,4 +2,12 @@ class Episode < ApplicationRecord
   has_one_attached :video
   belongs_to :movie
   has_many :episode_users, dependent: :destroy
+
+  def next_episode
+    movie.episodes.where("position > ?", position).order(:position).first
+  end
+
+  def previous_episode
+    movie.episodes.where("position < ?", position).order(:position).last
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <div class="w-full">
       <%= render "shared/navbar" %>
     </div>
-    <main class="container mx-auto mt-28 px-5 flex">
+    <main class="container mx-auto mt-6 px-5 flex">
       <%= yield %>
     </main>
   </body>


### PR DESCRIPTION
## Summary
This merge request introduces logic to restrict access to episodes for users who have not purchased the full movie. The changes ensure that users are redirected to the appropriate pages with notices if they attempt to access locked content.

## Changes
- Implemented `check_paid` method to check if the user has paid for the full movie before accessing subsequent episodes.
- Added conditional redirects to either the previous episode or the movie page with an appropriate notice if the user hasn't purchased the movie.
- Updated `next_episode` and `previous_episode` methods to fetch the next or previous episodes based on position.
- Integrated the `check_paid` method as a `before_action` filter to handle access control before episode actions.

## Checklist
- [X] Code has been tested locally.
- [X] UI changes have been reviewed.